### PR TITLE
Add a new view mode to data tables

### DIFF
--- a/packages/jdm-editor/src/components/decision-graph/graph/tab-decision-table.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/graph/tab-decision-table.tsx
@@ -1,5 +1,5 @@
 import type { DragDropManager } from 'dnd-core';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { P, match } from 'ts-pattern';
 
 import { useNodeType } from '../../../helpers/node-type';
@@ -50,22 +50,30 @@ export const TabDecisionTable: React.FC<TabDecisionTableProps> = ({ id, manager 
     return newType;
   }, [nodeType, globalType, content?.inputField, content?.executionMode]);
 
+  const [viewMode, setViewMode] = useState<'default' | 'new'>('default');
+
   return (
-    <DecisionTable
-      id={id}
-      tableHeight={'100%'}
-      value={content as any}
-      manager={manager}
-      disabled={disabled}
-      configurable={configurable}
-      inputData={computedType}
-      activeRules={(activeRules || []).filter((id) => !!id)}
-      onChange={(val) => {
-        graphActions.updateNode(id, (draft) => {
-          Object.assign(draft.content, val);
-          return draft;
-        });
-      }}
-    />
+    <div>
+      <button onClick={() => setViewMode(viewMode === 'default' ? 'new' : 'default')}>
+        Toggle View Mode
+      </button>
+      <DecisionTable
+        id={id}
+        tableHeight={'100%'}
+        value={content as any}
+        manager={manager}
+        disabled={disabled}
+        configurable={configurable}
+        inputData={computedType}
+        activeRules={(activeRules || []).filter((id) => !!id)}
+        onChange={(val) => {
+          graphActions.updateNode(id, (draft) => {
+            Object.assign(draft.content, val);
+            return draft;
+          });
+        }}
+        viewMode={viewMode}
+      />
+    </div>
   );
 };

--- a/packages/jdm-editor/src/components/decision-table/context/dt-store.context.tsx
+++ b/packages/jdm-editor/src/components/decision-table/context/dt-store.context.tsx
@@ -141,6 +141,8 @@ export type DecisionTableStoreType = {
 
     inputsSchema?: SchemaSelectProps[];
     outputsSchema?: SchemaSelectProps[];
+
+    viewMode: 'default' | 'new';
   };
 
   actions: {
@@ -156,6 +158,7 @@ export type DecisionTableStoreType = {
     removeColumn: (type: ColumnType, id: string) => void;
     reorderColumns: (type: ColumnType, columns: TableSchemaItem[]) => void;
     updateHitPolicy: (hitPolicy: HitPolicy) => void;
+    setViewMode: (viewMode: 'default' | 'new') => void;
   };
 
   listeners: {
@@ -204,6 +207,8 @@ export const DecisionTableProvider: React.FC<React.PropsWithChildren<DecisionTab
         derivedVariableTypes: {},
         inputVariableType: undefined,
         inputData: undefined,
+
+        viewMode: 'default',
       })),
     [],
   );
@@ -376,6 +381,9 @@ export const DecisionTableProvider: React.FC<React.PropsWithChildren<DecisionTab
 
         stateStore.setState({ decisionTable: updatedDecisionTable });
         listenerStore.getState().onChange?.(updatedDecisionTable);
+      },
+      setViewMode: (viewMode: 'default' | 'new') => {
+        stateStore.setState({ viewMode });
       },
     }),
     [],

--- a/packages/jdm-editor/src/components/decision-table/dt.stories.tsx
+++ b/packages/jdm-editor/src/components/decision-table/dt.stories.tsx
@@ -122,6 +122,7 @@ const meta: Meta<typeof DecisionTable> = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
+   * to learn how to generate automatic titles
    */
   title: 'Decision Table',
   component: DecisionTable,
@@ -256,6 +257,41 @@ export const StressTest: Story = {
         }}
       >
         <DecisionTable {...args} value={value} onChange={setValue} tableHeight='100%' />
+      </div>
+    );
+  },
+};
+
+export const ViewModeToggle: Story = {
+  render: (args) => {
+    const [value, setValue] = useState<DecisionTableType>(shippingFeesDefault);
+    const [viewMode, setViewMode] = useState<'default' | 'new'>('default');
+    const manager = useMemo(() => {
+      return createDragDropManager(HTML5Backend);
+    }, []);
+
+    return (
+      <div
+        style={{
+          height: '100%',
+        }}
+      >
+        <button onClick={() => setViewMode(viewMode === 'default' ? 'new' : 'default')}>
+          Toggle View Mode
+        </button>
+        <DecisionTable
+          {...args}
+          value={value}
+          manager={manager}
+          viewMode={viewMode}
+          onChange={(val) => {
+            console.log(val);
+            setValue(val);
+            args?.onChange?.(val);
+          }}
+          inputsSchema={inputSchemaDefault}
+          tableHeight='100%'
+        />
       </div>
     );
   },

--- a/packages/jdm-editor/src/components/decision-table/dt.tsx
+++ b/packages/jdm-editor/src/components/decision-table/dt.tsx
@@ -20,6 +20,7 @@ export type DecisionTableProps = {
   mountDialogsOnBody?: boolean;
   manager?: DragDropManager;
   inputData?: unknown;
+  viewMode?: 'default' | 'new';
 } & DecisionTableContextProps &
   DecisionTableEmptyType;
 
@@ -28,6 +29,7 @@ export const DecisionTable: React.FC<DecisionTableProps> = ({
   tableHeight,
   mountDialogsOnBody = false,
   manager,
+  viewMode = 'default',
   ...props
 }) => {
   const { token } = theme.useToken();
@@ -63,7 +65,7 @@ export const DecisionTable: React.FC<DecisionTableProps> = ({
           <DecisionTableProvider>
             <DecisionTableDialogProvider getContainer={mountDialogsOnBody ? undefined : getContainer}>
               <DecisionTableCommandBar />
-              <Table id={id} maxHeight={tableHeight} />
+              <Table id={id} maxHeight={tableHeight} viewMode={viewMode} />
               <DecisionTableDialogs />
               <DecisionTableEmpty {...props} />
             </DecisionTableDialogProvider>

--- a/packages/jdm-editor/src/components/decision-table/table/table-default-cell.tsx
+++ b/packages/jdm-editor/src/components/decision-table/table/table-default-cell.tsx
@@ -25,10 +25,11 @@ export const TableDefaultCell = memo<TableDefaultCellProps>(({ context, ...props
   } = context;
 
   const tableActions = useDecisionTableActions();
-  const { disabled, value, diff } = useDecisionTableState(({ decisionTable, disabled }) => ({
+  const { disabled, value, diff, viewMode } = useDecisionTableState(({ decisionTable, disabled, viewMode }) => ({
     value: decisionTable?.rules?.[index]?.[id],
     diff: (decisionTable?.rules?.[index] as any)?._diff?.fields?.[id],
     disabled,
+    viewMode,
   }));
 
   const column = useDecisionTableState(
@@ -64,7 +65,8 @@ export const TableDefaultCell = memo<TableDefaultCellProps>(({ context, ...props
         value: inner,
         diff,
         onChange: commit,
-      }) || <TableInputCell disabled={disabled} column={column} value={inner} onChange={commit} diff={diff} />}
+        viewMode,
+      }) || <TableInputCell disabled={disabled} column={column} value={inner} onChange={commit} diff={diff} viewMode={viewMode} />}
     </div>
   );
 });
@@ -75,6 +77,7 @@ export type TableCellProps = {
   diff?: DiffMetadata;
   onChange: (value: string) => void;
   disabled?: boolean;
+  viewMode: 'default' | 'new';
 };
 
 enum LocalVariableKind {
@@ -82,7 +85,7 @@ enum LocalVariableKind {
   Derived,
 }
 
-const TableInputCell: React.FC<TableCellProps> = ({ column, value, onChange, disabled, diff }) => {
+const TableInputCell: React.FC<TableCellProps> = ({ column, value, onChange, disabled, diff, viewMode }) => {
   const id = useMemo(() => crypto.randomUUID(), []);
   const textareaRef = useRef<HTMLTextAreaElement | HTMLDivElement>(null);
   const raw = useDecisionTableRaw();

--- a/packages/jdm-editor/src/components/decision-table/table/table-head-cell.tsx
+++ b/packages/jdm-editor/src/components/decision-table/table/table-head-cell.tsx
@@ -318,3 +318,21 @@ export const TableHeadCellOutputField: React.FC<TableHeadCellFieldProps> = ({ co
     </div>
   );
 };
+
+export const TableHeadCellToggleViewMode: React.FC = () => {
+  const { viewMode, setViewMode } = useDecisionTableState((state) => ({
+    viewMode: state.viewMode,
+    setViewMode: state.actions.setViewMode,
+  }));
+
+  return (
+    <Button
+      onClick={() => setViewMode(viewMode === 'default' ? 'new' : 'default')}
+      icon={<SwapOutlined />}
+      size={'small'}
+      type={'text'}
+    >
+      Toggle View Mode
+    </Button>
+  );
+};

--- a/packages/jdm-editor/src/components/decision-table/table/table-head-row.tsx
+++ b/packages/jdm-editor/src/components/decision-table/table/table-head-row.tsx
@@ -3,10 +3,13 @@ import { flexRender } from '@tanstack/react-table';
 import clsx from 'clsx';
 import React from 'react';
 import { match } from 'ts-pattern';
+import { TableHeadCellToggleViewMode } from './table-head-cell';
 
 export const TableHeadRow: React.FC<{ headerGroup: HeaderGroup<any> }> = ({ headerGroup }) => (
   <tr key={headerGroup.id}>
-    <th colSpan={1} style={{ width: 72 }} />
+    <th colSpan={1} style={{ width: 72 }}>
+      <TableHeadCellToggleViewMode />
+    </th>
     {headerGroup.headers.map((header) => {
       const context = header.getContext();
       const parent = context.header.column.parent?.id;

--- a/packages/jdm-editor/src/components/decision-table/table/table-row.tsx
+++ b/packages/jdm-editor/src/components/decision-table/table/table-row.tsx
@@ -14,7 +14,8 @@ export const TableRow: React.FC<{
   disabled?: boolean;
   virtualItem: VirtualItem;
   onResize?: (node: HTMLElement) => void;
-}> = ({ row, disabled, virtualItem, onResize }) => {
+  viewMode: 'default' | 'new';
+}> = ({ row, disabled, virtualItem, onResize, viewMode }) => {
   const trRef = useRef<HTMLTableRowElement>(null);
   const tableActions = useDecisionTableActions();
   const { cursor, isActive } = useDecisionTableState(({ cursor, activeRules }) => ({

--- a/packages/jdm-editor/src/components/decision-table/table/table.tsx
+++ b/packages/jdm-editor/src/components/decision-table/table/table.tsx
@@ -23,6 +23,7 @@ import { TableRow } from './table-row';
 export type TableProps = {
   id?: string;
   maxHeight: string | number;
+  viewMode: 'default' | 'new';
 };
 
 type ColumnSizing = Record<string, number>;
@@ -43,7 +44,7 @@ const loadColumnSizing = (id?: string) => {
   }
 };
 
-export const Table: React.FC<TableProps> = ({ id, maxHeight }) => {
+export const Table: React.FC<TableProps> = ({ id, maxHeight, viewMode }) => {
   const { token } = theme.useToken();
 
   const tableActions = useDecisionTableActions();
@@ -210,7 +211,7 @@ export const Table: React.FC<TableProps> = ({ id, maxHeight }) => {
             ))}
         </thead>
         <TableContextMenu>
-          <TableBody tableContainerRef={tableContainerRef} table={table} />
+          <TableBody tableContainerRef={tableContainerRef} table={table} viewMode={viewMode} />
         </TableContextMenu>
         <tfoot>
           <tr>
@@ -237,10 +238,11 @@ export const Table: React.FC<TableProps> = ({ id, maxHeight }) => {
 type TableBodyProps = {
   tableContainerRef: React.RefObject<HTMLDivElement>;
   table: ReactTable<any>;
+  viewMode: 'default' | 'new';
 } & Omit<React.HTMLAttributes<HTMLTableSectionElement>, 'children'>;
 
 const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
-  ({ table, tableContainerRef, ...props }, ref) => {
+  ({ table, tableContainerRef, viewMode, ...props }, ref) => {
     const tableActions = useDecisionTableActions();
     const { disabled, cursor } = useDecisionTableState(({ disabled, cursor }) => ({
       disabled,
@@ -295,6 +297,7 @@ const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
               row={row}
               disabled={disabled}
               onResize={(node) => virtualizer.measureElement(node)}
+              viewMode={viewMode}
             />
           );
         })}


### PR DESCRIPTION
Add a new view mode to the decision table component.

* **Decision Table Component**:
  - Add a new state variable `viewMode` to manage the view mode.
  - Add a button to toggle between view modes.
  - Pass the `viewMode` prop to the `DecisionTableProvider`.

* **Decision Table Store Context**:
  - Add a new state variable `viewMode` to the `DecisionTableStoreType`.
  - Add actions to update the `viewMode` state variable.

* **Table Component**:
  - Add a new prop `viewMode` to the `Table` component.
  - Add logic to render the table based on the `viewMode` prop.

* **Table Head Cell**:
  - Add a button to toggle between view modes.

* **Table Head Row**:
  - Add logic to render the table head based on the `viewMode` prop.

* **Table Row**:
  - Add logic to render the table rows based on the `viewMode` prop.

* **Table Default Cell**:
  - Add logic to render the table cells based on the `viewMode` prop.

* **Storybook**:
  - Add tests for the new view mode functionality.

